### PR TITLE
Code corrected; type annotation error won't cause problems for installation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -85,7 +85,7 @@ fn main() -> Result<(), io::Error> {
             }
 
             let helpbar_chunk = Layout::default()
-                .constraints(constraints.as_ref())
+                .constraints::<&[Constraint]>(constraints.as_ref())
                 .split(f.size());
 
             if app.help_bar().shown() {


### PR DESCRIPTION
When running `cargo install --path . # copies binary to /.cargo/bin/`, the cargo installation returned an [E0283] Type Annotation error. I changed line 88, now the installation actually works.